### PR TITLE
Update FlutterTwilioVoicePlugin.java

### DIFF
--- a/android/src/main/java/com/dormmom/flutter_twilio_voice/FlutterTwilioVoicePlugin.java
+++ b/android/src/main/java/com/dormmom/flutter_twilio_voice/FlutterTwilioVoicePlugin.java
@@ -85,7 +85,7 @@ public class FlutterTwilioVoicePlugin implements FlutterPlugin, MethodChannel.Me
 
         plugin.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         plugin.voiceBroadcastReceiver = new VoiceBroadcastReceiver(plugin);
-        plugin.registerReceiver();
+        //plugin.registerReceiver();
 
         /*
          * Needed for setting/abandoning audio focus during a call


### PR DESCRIPTION
plugin.registerReceiver() called when `activity` is still null at flutter 1.22.
At this stage the bug crashes the whole app, this bug is unidentifiable as you receive errors from other plugins that failed to register.