### PR TITLE
expose channel messages as streams

### DIFF
--- a/lib/flutter_twilio_voice.dart
+++ b/lib/flutter_twilio_voice.dart
@@ -3,8 +3,26 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-enum CallState { ringing, connected, call_ended, unhold, hold, unmute, mute, speaker_on, speaker_off, log, answer }
+enum EventChannelMessageType { log, call_state, token }
+enum CallState { ringing, connected, call_ended, unhold, hold, unmute, mute, speaker_on, speaker_off, answer }
 enum CallDirection { incoming, outgoing }
+
+class EventChannelMessage
+{
+  final EventChannelMessageType type;
+  final String serializedPayload;
+
+  EventChannelMessage(this.type, this.serializedPayload);
+}
+
+class LogEntry
+{
+  final String severity;
+  final String message;
+  final String exception;
+
+  LogEntry(this.severity, this.message, [this.exception]);
+}
 
 typedef OnDeviceTokenChanged = Function(String token);
 
@@ -13,18 +31,60 @@ class FlutterTwilioVoice {
 
   static const EventChannel _eventChannel = EventChannel('flutter_twilio_voice/events');
 
-  static Stream<CallState> _onCallStateChanged;
+  static Stream<CallState> _callStateMessages;
+  static Stream<LogEntry> _logEntryMessages;
+  static Stream<String> _deviceTokenMessages;
+  static Stream<EventChannelMessage> _eventChannelMessages;
   static String callFrom;
   static String callTo;
   static int callStartedOn;
   static CallDirection callDirection = CallDirection.incoming;
   static OnDeviceTokenChanged deviceTokenChanged;
 
-  static Stream<CallState> get onCallStateChanged {
-    if (_onCallStateChanged == null) {
-      _onCallStateChanged = _eventChannel.receiveBroadcastStream().map((dynamic event) => _parseCallState(event));
+  static Stream<EventChannelMessage> get eventChannelMessages {
+    if (_eventChannelMessages == null) {
+      _eventChannelMessages = _eventChannel.receiveBroadcastStream()
+                                .map((event) => _parseEventChannelMessage(event));
     }
-    return _onCallStateChanged;
+    return _eventChannelMessages;
+  }
+
+  static Stream<CallState> get callStateMessages {
+    if (_callStateMessages == null) {
+      _callStateMessages = eventChannelMessages
+                              .where((event) => event.type != EventChannelMessageType.log)
+                              .map((event) => _parseCallStateMessage(event.serializedPayload));
+    }
+    return _callStateMessages;
+  }
+
+  static Stream<String> get deviceTokenMessages {
+    if (_deviceTokenMessages == null) {
+      _deviceTokenMessages = eventChannelMessages
+                              .where((event) => event.type == EventChannelMessageType.token)
+                              .map((event) => _parseDeviceTokenMessage(event.serializedPayload));
+
+      // historical behavior - on subscription, we start a listener to fire the old event.
+      // Technically, the only event is no longer needed - as we have streams.
+      _deviceTokenMessages
+        .listen((event) => deviceTokenChanged(event));
+    }
+    return _deviceTokenMessages;
+  }
+
+  static var _logStreamController = StreamController<LogEntry>();
+
+  static Stream<LogEntry> get logEntryMessages {
+    if (_logEntryMessages == null) {
+      
+      eventChannelMessages
+        .where((event) => event.type == EventChannelMessageType.log)
+        .map((event) => _parseLogEntryMessage(event.serializedPayload))
+        .listen((event) => _logStreamController.add(event));
+     
+      _logEntryMessages = _logStreamController.stream;
+    }
+    return _logEntryMessages;
   }
 
   static void setOnDeviceTokenChanged(OnDeviceTokenChanged deviceTokenChanged) {
@@ -130,72 +190,125 @@ class FlutterTwilioVoice {
     return callDirection;
   }
 
-  static CallState _parseCallState(String state) {
-    if (state.startsWith("DEVICETOKEN|")) {
-      var token = state.split('|')[1];
-      if (deviceTokenChanged != null) {
-        deviceTokenChanged(token);
-      }
-      return CallState.log;
-    } else if (state.startsWith("LOG|")) {
-      List<String> tokens = state.split('|');
-      print(tokens[1]);
-      return CallState.log;
-    } else if (state.startsWith("Connected|")) {
-      List<String> tokens = state.split('|');
-      callFrom = _prettyPrintNumber(tokens[1]);
-      callTo = _prettyPrintNumber(tokens[2]);
-      callDirection = ("Incoming" == tokens[3] ? CallDirection.incoming : CallDirection.outgoing);
-      if (callStartedOn == null) {
-        callStartedOn = DateTime.now().millisecondsSinceEpoch;
-      }
-      print('Connected - From: $callFrom, To: $callTo, StartOn: $callStartedOn, Direction: $callDirection');
-      return CallState.connected;
-    } else if (state.startsWith("Ringing|")) {
-      List<String> tokens = state.split('|');
-      callFrom = _prettyPrintNumber(tokens[1]);
-      callTo = _prettyPrintNumber(tokens[2]);
+  static List<String> splitAtFirstPipe(String sz)
+    => sz.split(RegExp(r"(?<!.*\|.*)\|")).toList();
 
-      print('Ringing - From: $callFrom, To: $callTo, Direction: $callDirection');
-      return CallState.ringing;
-    } else if (state.startsWith("Answer")) {
-      List<String> tokens = state.split('|');
-      callFrom = _prettyPrintNumber(tokens[1]);
-      callTo = _prettyPrintNumber(tokens[2]);
-      callDirection = CallDirection.incoming;
-      print('Answer - From: $callFrom, To: $callTo, Direction: $callDirection');
-      return CallState.answer;
+  static LogEntry _parseLogEntryMessage(String serializedMessage) 
+  {
+    // _logStreamController.add(LogEntry('WARN', 'custom log message'));
+    var levelAndMessage = splitAtFirstPipe(serializedMessage);
+    var level = '';
+    var message = '';
+    if (levelAndMessage.length == 1)
+    {
+      message = levelAndMessage[0];
+    } else if (levelAndMessage.length == 2)
+    {
+      level = levelAndMessage[0];
+      message = levelAndMessage[1];
     }
-    switch (state) {
-      case 'Ringing':
-        return CallState.ringing;
-      case 'Connected':
-        return CallState.connected;
-      case 'Call Ended':
-        callStartedOn = null;
-        callFrom = null;
-        callTo = null;
-        callDirection = CallDirection.incoming;
-        return CallState.call_ended;
-      case 'Unhold':
-        return CallState.unhold;
-      case 'Hold':
-        return CallState.hold;
-      case 'Unmute':
-        return CallState.unmute;
-      case 'Mute':
-        return CallState.mute;
-      case 'Speaker On':
-        return CallState.speaker_on;
-      case 'Speaker Off':
-        return CallState.speaker_off;
+    return LogEntry(level, message);
+  }
+
+  static EventChannelMessage _parseEventChannelMessage(String serializedMessage) {
+    var typeAndPayload = splitAtFirstPipe(serializedMessage);
+    switch(typeAndPayload[0])
+    {
+      case "DEVICETOKEN":
+        return EventChannelMessage(EventChannelMessageType.token, typeAndPayload[1]);
+      case "LOG":
+        return EventChannelMessage(EventChannelMessageType.log, typeAndPayload[1]);
+      case "Connected":
+      case "Ringing":
+      case "Answer":
+      case "Call Ended":
+      case "Hold":
+      case "Unhold":
+      case "Mute":
+      case "Unmute":
+      case "Speaker On":
+      case "Speaker Off":
+        return EventChannelMessage(EventChannelMessageType.call_state, serializedMessage);
       default:
-        print('$state is not a valid CallState.');
-        throw ArgumentError('$state is not a valid CallState.');
+        return EventChannelMessage(EventChannelMessageType.log, 'WARN|Unknown event type ${typeAndPayload[0]}');
     }
   }
 
+  static String _parseDeviceTokenMessage(String serializedPayload) {
+      return serializedPayload;
+  }
+
+  static CallState _parseCallStateMessage(String serializedPayload) {
+    CallState result;
+    var stateAndPayload = splitAtFirstPipe(serializedPayload);
+    try{
+      var state = stateAndPayload[0];
+      var payload = stateAndPayload.length == 2 ? stateAndPayload[1].split('|') : [];
+      switch (state)
+      {
+        case 'Connected':
+          callFrom = _prettyPrintNumber(payload[0]);
+          callTo = _prettyPrintNumber(payload[1]);
+          callDirection = ("Incoming" == payload[2] ? CallDirection.incoming : CallDirection.outgoing);
+          if (callStartedOn == null) {
+            callStartedOn = DateTime.now().millisecondsSinceEpoch;
+          }
+          print('Connected - From: $callFrom, To: $callTo, StartOn: $callStartedOn, Direction: $callDirection');
+          result = CallState.connected;
+        break;
+        case 'Ringing':
+          callFrom = _prettyPrintNumber(payload[0]);
+          callTo = _prettyPrintNumber(payload[1]);
+
+          print('Ringing - From: $callFrom, To: $callTo, Direction: $callDirection');
+          result = CallState.ringing;      
+        break;
+        case 'Answer':
+          callFrom = _prettyPrintNumber(payload[0]);
+          callTo = _prettyPrintNumber(payload[1]);
+          callDirection = CallDirection.incoming;
+          print('Answer - From: $callFrom, To: $callTo, Direction: $callDirection');
+          result = CallState.answer;
+        break;
+        case 'Call Ended':
+          callStartedOn = null;
+          callFrom = null;
+          callTo = null;
+          callDirection = CallDirection.incoming;
+          result = CallState.call_ended;
+        break;      
+        case 'Unhold':
+          result = CallState.unhold;
+          break;
+        case 'Hold':
+          result = CallState.hold;
+          break;
+        case 'Unmute':
+          result = CallState.unmute;
+          break;
+        case 'Mute':
+          result = CallState.mute;
+          break;
+        case 'Speaker On':
+          result = CallState.speaker_on;
+          break;
+        case 'Speaker Off':
+          result = CallState.speaker_off;
+          break;
+        default:
+          print('$state is not a valid CallState.');
+          throw ArgumentError('$state is not a valid CallState.');
+      }
+    } catch(e) {
+      _logStreamController.add(LogEntry('ERROR', 'Unable to parse CallState message "$serializedPayload"'));
+    }
+    return result;
+  }
+
   static String _prettyPrintNumber(String phoneNumber) {
+    if (null == phoneNumber || phoneNumber == '')
+      return '';
+
     if (phoneNumber.indexOf('client:') > -1) {
       return phoneNumber.split(':')[1];
     }


### PR DESCRIPTION
Current implementation did not allow for outsiders to easily consume the various messages coming from the Swift plugin.
For example - log messages were consumed, printed, and lost.
New design divides messages into 3 types, log, call-state, and token, and exposes them as streams for anyone to consume:

```
static Stream<EventChannelMessage> get eventChannelMessages;
static Stream<CallState> get callStateMessages;
static Stream<String> get deviceTokenMessages;
```

Each stream has its own parse function, splitting up this logic from the previous '_parseCallState' function - which was doing a lot more work than it really should.

This makes more sense as log and token messages are not really "call state". Now can easily subscribe to "log" messages, and pipe them through to what ever logging framework you're using... e.g Flog.

Still not a perfect design, but a small step in the right direction.
I do wonder about using something like protobuf for messaging - but probably overkill for this.